### PR TITLE
Format code examples with `black`

### DIFF
--- a/dask/cpu-gpu.py
+++ b/dask/cpu-gpu.py
@@ -20,4 +20,4 @@ if __name__ == "__main__":
     # back to NumPy
     z = y.map_blocks(cupy.asnumpy)
 
-    assert(z.max().compute() == 1)
+    assert z.max().compute() == 1

--- a/dask/memory.py
+++ b/dask/memory.py
@@ -8,8 +8,10 @@ if __name__ == "__main__":
     cluster = LocalCUDACluster()
     client = Client(cluster)
 
+
 def increment(arr: cupy.ndarray) -> cupy.ndarray:
     return arr + 1
+
 
 if __name__ == "__main__":
 
@@ -17,9 +19,7 @@ if __name__ == "__main__":
     chunks = (2**30,)
 
     with dask.config.set({"array.backend": "cupy"}):
-        x = dask.array.full(
-            shape, 42, chunks=chunks, dtype=int8
-        )
+        x = dask.array.full(shape, 42, chunks=chunks, dtype=int8)
 
     # only the persisted values are kept around
     # refs to non-persisted values don't matter

--- a/dask/partitioning.py
+++ b/dask/partitioning.py
@@ -8,8 +8,10 @@ if __name__ == "__main__":
     cluster = LocalCUDACluster()
     client = Client(cluster)
 
+
 def batched_fft(src: cupy.ndarray) -> cupy.ndarray:
     return cupy.fft.fftn(src, axes=(0,))
+
 
 if __name__ == "__main__":
 
@@ -18,9 +20,7 @@ if __name__ == "__main__":
     chunks = (1024, 512)
 
     with dask.config.set({"array.backend": "cupy"}):
-        x = dask.array.full(
-            shape, 42, chunks=chunks, dtype=complex64
-        )
+        x = dask.array.full(shape, 42, chunks=chunks, dtype=complex64)
 
     y = x.map_blocks(batched_fft)
     wait(y.persist())

--- a/dask/task-placement.py
+++ b/dask/task-placement.py
@@ -11,19 +11,17 @@ if __name__ == "__main__":
     client = Client(cluster)
 
     # one worker per GPU
-    w0, w1 = client.scheduler_info()['workers'].keys()
+    w0, w1 = client.scheduler_info()["workers"].keys()
 
     shape = (2**21,)
     chunks = (2**20,)
 
     with dask.config.set({"array.backend": "cupy"}):
         # data is initialized in two chunks
-        x = dask.array.ones(
-            shape, chunks=chunks, dtype=int8
-        )
+        x = dask.array.ones(shape, chunks=chunks, dtype=int8)
 
     # full data is pulled to GPU 0, work happens there
     with dask.annotate(workers=(w0,)):
         y = x + 1
 
-    assert(y.max().compute() == 2)
+    assert y.max().compute() == 2

--- a/dask/tasking.py
+++ b/dask/tasking.py
@@ -1,7 +1,9 @@
 import dask
 
+
 @dask.delayed
 def hello():
     print("Hello, world")
+
 
 hello.compute()()

--- a/legate/cpu-gpu.py
+++ b/legate/cpu-gpu.py
@@ -11,9 +11,11 @@ GPU = legate.core.VariantCode.GPU
 runtime = get_legate_runtime()
 machine = get_machine()
 
+
 @task(variants=(CPU,))
 def initialize(dst: OutputStore) -> None:
     numpy.asarray(dst)[:] = 1
+
 
 shape = (2**31,)
 x = runtime.create_store(int8, shape)

--- a/legate/downstream.py
+++ b/legate/downstream.py
@@ -11,9 +11,9 @@ ary = cupynumeric.ones(shape, int32)
 # through the Legate Data Interface
 # in this case, no repartitioning needs to happen
 col = LogicalColumn(ary)
-print(reduce(col, aggregation.sum(), int32)) # 1024
+print(reduce(col, aggregation.sum(), int32))  # 1024
 
 # the column and array refer to the same data
 # whether or not repartitioning needed to happen
 cupynumeric.add(ary, 1, out=ary)
-print(reduce(col, aggregation.sum(), int32)) # 2048
+print(reduce(col, aggregation.sum(), int32))  # 2048

--- a/legate/memory.py
+++ b/legate/memory.py
@@ -8,11 +8,11 @@ GPU = legate.core.VariantCode.GPU
 SYSMEM = legate.core.StoreTarget.SYSMEM
 runtime = get_legate_runtime()
 
+
 @task(variants=(GPU,))
-def increment(
-    dst: OutputStore, src: InputStore
-) -> None:
+def increment(dst: OutputStore, src: InputStore) -> None:
     cupy.asarray(dst)[:] = cupy.asarray(src) + 1
+
 
 shape = (2**31,)
 x = runtime.create_store(int8, shape)

--- a/legate/partitioning.py
+++ b/legate/partitioning.py
@@ -7,19 +7,24 @@ from legate.core.types import complex64
 GPU = legate.core.VariantCode.GPU
 runtime = get_legate_runtime()
 
+
 @task(
     variants=(GPU,),
     constraints=(
         # partition these in the same way
         align("dst", "src"),
         # don't split the first dimension
-        broadcast("src", (0,))))
+        broadcast("src", (0,)),
+    ),
+)
 def batched_fft(
-    dst: OutputStore, src: InputStore,
+    dst: OutputStore,
+    src: InputStore,
 ):
     cp_dst = cupy.asarray(dst)
     cp_src = cupy.asarray(src)
     cp_dst[:] = cupy.fft.fftn(cp_src, axes=(0,))
+
 
 shape = (1024, 1024)
 x = runtime.create_store(complex64, shape)

--- a/legate/repartition.py
+++ b/legate/repartition.py
@@ -7,15 +7,16 @@ from legate.core.types import int8
 GPU = legate.core.VariantCode.GPU
 runtime = get_legate_runtime()
 
-@task(variants=(GPU,),
-      constraints=(broadcast("x", (1,)),))
+
+@task(variants=(GPU,), constraints=(broadcast("x", (1,)),))
 def row_wise(x: InputStore) -> None:
     assert cupy.asarray(x).shape == (500, 3000)
 
-@task(variants=(GPU,),
-      constraints=(broadcast("x", (0,)),))
+
+@task(variants=(GPU,), constraints=(broadcast("x", (0,)),))
 def col_wise(x: InputStore) -> None:
     assert cupy.asarray(x).shape == (1000, 1500)
+
 
 store = runtime.create_store(int8, (1000, 3000))
 runtime.issue_fill(store, 1)

--- a/legate/task-placement.py
+++ b/legate/task-placement.py
@@ -9,11 +9,11 @@ GPU = legate.core.VariantCode.GPU
 runtime = get_legate_runtime()
 machine = get_machine()
 
+
 @task(variants=(GPU,))
-def increment(
-    dst: OutputStore, src: InputStore
-) -> None:
+def increment(dst: OutputStore, src: InputStore) -> None:
     cupy.asarray(dst)[:] = cupy.asarray(src) + 1
+
 
 shape = (2**20,)
 x = runtime.create_store(int8, shape)
@@ -23,4 +23,4 @@ runtime.issue_fill(x, 1)
 with machine.only(TaskTarget.GPU)[0]:
     increment(x, x)
 
-assert(cupynumeric.asarray(x).max() == 2)
+assert cupynumeric.asarray(x).max() == 2

--- a/legate/tasking.py
+++ b/legate/tasking.py
@@ -1,7 +1,9 @@
 from legate.core.task import task
 
+
 @task
 def hello():
     print("Hello, world")
+
 
 hello()

--- a/legate/toplevel.py
+++ b/legate/toplevel.py
@@ -7,15 +7,16 @@ from legate.core.types import int32
 GPU = legate.core.VariantCode.GPU
 runtime = get_legate_runtime()
 
+
 @task(variants=(GPU,))
 def initialize(dst: OutputStore) -> None:
     cupy.asarray(dst)[:] = 1
 
+
 @task(variants=(GPU,))
-def increment(
-    dst: OutputStore, src: InputStore
-) -> None:
+def increment(dst: OutputStore, src: InputStore) -> None:
     cupy.asarray(dst)[:] = cupy.asarray(src) + 1
+
 
 # initialize data scattered across GPUs
 x = runtime.create_store(int32, (2**20,))
@@ -28,5 +29,3 @@ assert y.sum() == 2**20
 # remote data and local view are kept in sync
 increment(x, x)
 assert y.sum() == 2**21
-
-

--- a/legate/view.py
+++ b/legate/view.py
@@ -9,15 +9,15 @@ CPU = legate.core.VariantCode.CPU
 GPU = legate.core.VariantCode.GPU
 runtime = get_legate_runtime()
 
-@task(variants=(CPU,GPU))
-def fill(
-    to_fill: OutputStore, val: int
-) -> None:
+
+@task(variants=(CPU, GPU))
+def fill(to_fill: OutputStore, val: int) -> None:
     try:
         arr = numpy.asarray(to_fill)
     except ValueError:
         arr = cupy.asarray(to_fill)
     arr[:] = val
+
 
 array = runtime.create_array(int64, (9, 9))
 


### PR DESCRIPTION
Really enjoyed your talk! These comparison examples are really useful.

Small note, I think most of the PyData community has been conditioned by reading Python code that has been formatted with [black](https://github.com/psf/black). I found these examples a little hard to skim because the code formatting felt more like C++ than Python.

This PR runs `black` on all the Python files.